### PR TITLE
onInput applies to all elements with contenteditable enabled

### DIFF
--- a/src/DOM/HTML/Indexed.purs
+++ b/src/DOM/HTML/Indexed.purs
@@ -46,6 +46,7 @@ type GlobalAttributes r =
 
 type GlobalEvents r =
   ( onContextMenu :: Event
+  , onInput :: Event
   | r
   )
 
@@ -359,7 +360,6 @@ type HTMLinput = Interactive
   , onAbort :: Event
   , onChange :: Event
   , onError :: Event
-  , onInput :: Event
   , onInvalid :: Event
   , onLoad :: Event
   , onSearch :: Event
@@ -581,7 +581,6 @@ type HTMLtextarea = Interactive
   , maxLength :: Int
   , name :: String
   , onChange :: Event
-  , onInput :: Event
   , onScroll :: Event
   , onSelect :: Event
   , placeholder :: String


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
> The event also applies to elements with contenteditable enabled, and to any element when designMode is turned on.