### PR TITLE
Add onAuxClick to MouseEvents

### DIFF
--- a/src/DOM/HTML/Indexed.purs
+++ b/src/DOM/HTML/Indexed.purs
@@ -52,6 +52,7 @@ type GlobalEvents r =
 type MouseEvents r =
   ( onDoubleClick :: MouseEvent
   , onClick :: MouseEvent
+  , onAuxClick :: MouseEvent
   , onMouseDown :: MouseEvent
   , onMouseEnter :: MouseEvent
   , onMouseLeave :: MouseEvent


### PR DESCRIPTION
Add onAuxClick to MouseEvents for handling middle click/ctrl+click

Related: https://github.com/purescript-web/purescript-web-uievents/issues/18