### PR TITLE
add onBeforeInput to GlobalEvents

### DIFF
--- a/src/DOM/HTML/Indexed.purs
+++ b/src/DOM/HTML/Indexed.purs
@@ -48,6 +48,7 @@ type GlobalAttributes r =
 type GlobalEvents r =
   ( onContextMenu :: Event
   , onInput :: Event
+  , onBeforeInput :: Event
   | r
   )
 


### PR DESCRIPTION
Closes #31 

Adds support for [beforeinput](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event) events within GlobalEvents.

It is placed there, because every element can made editable via `contenteditable` or `designMode`, and so every element can fire beforeinput events.